### PR TITLE
refactor(django): upgrade to django 3.2 LTS

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.6-slim-buster
+ARG PYTHON_VERSION=3.9-slim-buster
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} as python

--- a/parkhang/frontend/package-lock.json
+++ b/parkhang/frontend/package-lock.json
@@ -1036,11 +1036,11 @@
       "integrity": "sha512-98fB+yo7imSD2F7PF7GIpELNgtLNgo5wjivu0W5V4jx+KVVJxo6p/qN4zdzSTBWy4/sN3pPyXwnhRSD28QX+ag=="
     },
     "@types/jszip": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.1.6.tgz",
-      "integrity": "sha512-m8uFcI+O2EupCfbEVQWsBM/4nhbegjOHL7cQgBpM95FeF98kdFJXzy9/8yhx4b3lCRl/gMBhcvyh30Qt3X+XPQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.1.tgz",
+      "integrity": "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==",
       "requires": {
-        "@types/node": "*"
+        "jszip": "*"
       }
     },
     "@types/minimatch": {
@@ -5079,16 +5079,16 @@
       }
     },
     "docx": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-4.7.1.tgz",
-      "integrity": "sha512-MTToHT11MV8Srnzy+JJ2gyotEhub3t5ey+96J12OCMujvLGjEoLigtTnIvMonKlA+TvDtNKbGsiU2h8WOD6wdw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-4.3.0.tgz",
+      "integrity": "sha512-ovEP2/8oZyKKk8Dhss7snn5602/IaLGoC1PR0R81NfE/l5J5VT9tc2uVkKrClYzCs8PEF1QjeygeXFWrViUcug==",
       "requires": {
         "@types/image-size": "0.0.29",
-        "@types/jszip": "^3.1.4",
+        "@types/jszip": "^3.1.3",
+        "fast-xml-parser": "^3.3.6",
         "image-size": "^0.6.2",
         "jszip": "^3.1.5",
-        "xml": "^1.0.1",
-        "xml-js": "^1.6.8"
+        "xml": "^1.0.1"
       }
     },
     "dom-converter": {
@@ -6278,6 +6278,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "requires": {
+        "strnum": "^1.0.4"
+      }
     },
     "fastparse": {
       "version": "1.1.2",
@@ -10590,9 +10598,9 @@
       }
     },
     "jszip": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -14601,6 +14609,15 @@
       "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==",
       "dev": true
     },
+    "redux-first-router": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/redux-first-router/-/redux-first-router-2.1.5.tgz",
+      "integrity": "sha512-roA/oYBLiJwdUf9c8pDmd4/xk2Jw8qe4MnSWPSHOuYPqyDmk30Pv9hZouwS6fZrPWL6VGJjrx67SwU6zBN/MKw==",
+      "requires": {
+        "rudy-history": "^1.0.0",
+        "rudy-match-path": "^0.3.0"
+      }
+    },
     "redux-logger": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
@@ -15071,6 +15088,11 @@
         "value-or-function": "^3.0.0"
       }
     },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -15154,6 +15176,41 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
       "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
       "dev": true
+    },
+    "rudy-history": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rudy-history/-/rudy-history-1.0.0.tgz",
+      "integrity": "sha512-UTW+bwDNXurwxBaLl7hixG8OW3nwhbtUFipGJ6hmyHFASihWiZQbcg0noqe3gqmmk+zVRBblls9sguAvTx+ciQ==",
+      "requires": {
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "value-equal": "^0.4.0",
+        "warning": "^3.0.0"
+      }
+    },
+    "rudy-match-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rudy-match-path/-/rudy-match-path-0.3.0.tgz",
+      "integrity": "sha512-xxdsPJZr7JtOibXCBYFmAgiEOvw1QK1rLSQ5sHiBvyzyD08rwjIZwg00Lt4G80g/4mhu639CSxRxQA4H+d1OHw==",
+      "requires": {
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "run-async": {
       "version": "2.3.0",
@@ -16227,6 +16284,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "style-loader": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
@@ -17263,6 +17325,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+    },
     "value-or-function": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
@@ -17486,6 +17553,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {
@@ -18131,14 +18206,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
-    },
-    "xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "requires": {
-        "sax": "^1.2.4"
-      }
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/parkhang/project/settings/base.py
+++ b/parkhang/project/settings/base.py
@@ -51,10 +51,12 @@ LANGUAGES = [
     ('bo', _('Tibetan'))
 ]
 
-# GENERAL
+# DATABASES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {"default": env.db("DATABASE_URL")}
+# https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # URLS
 # ------------------------------------------------------------------------------
@@ -169,7 +171,7 @@ TEMPLATES = [
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [str(ROOT_DIR / 'static')]
+STATICFILES_DIRS = [str(ROOT_DIR / 'frontend' / 'static')]
 
 # django-rest-framework
 # -------------------------------------------------------------------------------
@@ -200,7 +202,7 @@ DEFAULT_FROM_EMAIL = 'Nalanda Works <server@nalanda.works>'
 
 # WEBPACK
 WEBPACK_LOADER = {
-    'MAIN': {
+    'DEFAULT': {
         'BUNDLE_DIR_NAME': 'static/bundles/',
         'STATS_FILE': str(ROOT_DIR / 'frontend/webpack-stats.json'),
     }

--- a/parkhang/project/templates/home.html
+++ b/parkhang/project/templates/home.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
-    {% render_bundle 'parkhang' 'css' config='MAIN' %}
+    {% render_bundle 'parkhang' 'css' %}
     <script>
 
 {% if user.is_authenticated %}
@@ -22,6 +22,6 @@ USER_LOCALE = "bo";
 </head>
 <body>
 <div id="app" style="width: 100vw; height: 100vh;"></div>
-{% render_bundle 'parkhang' 'js' config='MAIN' %}
+{% render_bundle 'parkhang' 'js' %}
 </body>
 </html>

--- a/parkhang/requirements/base.txt
+++ b/parkhang/requirements/base.txt
@@ -2,10 +2,10 @@
 
 # Django
 # -----------------------------------------------------------------------
-Django==1.11
+django==3.2.12  # pyup: < 4.0  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
-django-allauth==0.31.0
-django-webpack-loader==0.4.1
+django-allauth==0.48.0  # https://github.com/pennersr/django-allauth
+django-webpack-loader==1.4.1 #https://github.com/django-webpack/django-webpack-loader
 
 # Django REST Framework
-djangorestframework==3.6.2
+djangorestframework==3.13.1  # https://github.com/encode/django-rest-framework

--- a/parkhang/texts/models.py
+++ b/parkhang/texts/models.py
@@ -1,3 +1,4 @@
+from operator import mod
 import uuid
 from enum import Enum
 
@@ -73,8 +74,8 @@ class Witness(models.Model):
     need to be updated/created to point to the correct place in the new version.
     """
 
-    text = models.ForeignKey(Text)
-    source = models.ForeignKey(Source)
+    text = models.ForeignKey(Text, on_delete=models.CASCADE)
+    source = models.ForeignKey(Source, on_delete=models.CASCADE)
     """Revision of this witness. Increases if it changes."""
     revision = models.PositiveIntegerField(default=1)
     """The text content of the witness"""
@@ -106,7 +107,7 @@ class Annotation(models.Model):
         (AnnotationType.line_break.value, 'Line Break')
     )
     unique_id = models.UUIDField(unique=True, editable=False, default=uuid.uuid4)
-    witness = models.ForeignKey(Witness)
+    witness = models.ForeignKey(Witness, null=True, blank=True, on_delete=models.SET_NULL)
     start = models.IntegerField()
     length = models.IntegerField()
     content = models.CharField(max_length=DEFAULT_MAX_LENGTH, null=True, blank=True)
@@ -129,7 +130,7 @@ class Annotation(models.Model):
             return self.creator_witness
         if self.creator_user:
             return self.creator_user
-        
+
         return None
 
     def creator_name(self):
@@ -157,9 +158,9 @@ class UserAnnotationOperation(models.Model):
         ('R', 'Removed'),
     )
 
-    user = models.ForeignKey(settings.AUTH_USER_MODEL)
-    annotation = models.ForeignKey(Annotation)
-    witness = models.ForeignKey(Witness)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL)
+    annotation = models.ForeignKey(Annotation, null=True, blank=True, on_delete=models.SET_NULL)
+    witness = models.ForeignKey(Witness, null=True, blank=True, on_delete=models.SET_NULL)
     operation = models.CharField(max_length=1, choices=OPERATION_CHOICES)
     """Intended to allow a user to say why they applied this annotation"""
     note = models.TextField(null=True, blank=True)
@@ -173,8 +174,5 @@ class DefaultWitnessAnnotations(models.Model):
     or via automation, not by end users.
     """
 
-    witness = models.ForeignKey(Witness)
-    annotation = models.ForeignKey(Annotation)
-
-
-
+    witness = models.ForeignKey(Witness, null=True, blank=True, on_delete=models.SET_NULL)
+    annotation = models.ForeignKey(Annotation, null=True, blank=True, on_delete=models.SET_NULL)

--- a/parkhang/users/models.py
+++ b/parkhang/users/models.py
@@ -1,7 +1,7 @@
 import re
 
 from django.db import models
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from django.core.mail import send_mail
 from django.contrib.postgres.fields import JSONField


### PR DESCRIPTION
Why upgrade now?
-------------------------
- we are starting a fresh deploy
- django 1.11 LTS (current version) support has ended at April 1, 2021